### PR TITLE
New fields and exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+.coverage.*
 
 # C extensions
 *.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 # Install pytest python library as well as add all files in current directory
-FROM python:3 AS base
+FROM python:3.7 AS base
 WORKDIR /usr/src/app
 RUN apt-get update \
     && apt-get install -y enchant \
     && rm -rf /var/lib/apt/lists/*
-RUN pip install --upgrade pip
+
 RUN pip install coveralls
-ADD . .
+ADD requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+
+ADD . .
+RUN pip install --no-cache-dir -e .
+
 RUN python ./setup.py test
 CMD ["python", "./setup.py", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install coveralls
 ADD requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-ADD . .
+COPY . .
 RUN pip install --no-cache-dir -e .
 
 RUN python ./setup.py test

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+2.4 (2018-12-01)
+++++++++++++++++
+
+* Fixed length validator.
+* Added Python 3.7 support.
+
 2.3 (2018-02-04)
 ++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Features
 
     >>> dog = Dog()
     >>> dog.validate()
-    *** ValidationError: Field "name" is required!
+    *** FieldValidationError: Error for field 'name': Field is required!
 
 * Cast models to python struct and JSON:
 
@@ -336,6 +336,18 @@ Features
     True
     >>> compare_schemas(schema1, schema2)
     False
+
+* Create custom reusable fields:
+
+  .. code-block:: python
+
+    class NameField(fields.StringField):
+        def __init__(self):
+            super().__init__(required=True)
+
+    class Person(models.Base):
+        name = NameField()
+        surnames = fields.DerivedListField(NameField())
 
 More
 ----

--- a/jsonmodels/__init__.py
+++ b/jsonmodels/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Szczepan Cieślik'
 __email__ = 'szczepan.cieslik@gmail.com'
-__version__ = '2.3'
+__version__ = '2.4'

--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -67,6 +67,8 @@ class ObjectBuilder(Builder):
 
     def add_field(self, name, field, schema):
         _apply_validators_modifications(schema, field)
+        if field.help_text:
+            schema["description"] = field.help_text
         self.properties[name] = schema
         if field.required:
             self.required.append(name)
@@ -158,6 +160,7 @@ class PrimitiveBuilder(Builder):
             obj_type = 'number'
         elif issubclass(self.type, float):
             obj_type = 'number'
+            schema['format'] = 'float'
         else:
             raise errors.FieldNotSupported(self.type)
 

--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -67,7 +67,7 @@ class ObjectBuilder(Builder):
 
     def add_field(self, name, field, schema):
         _apply_validators_modifications(schema, field)
-        if field.help_text:
+        if isinstance(schema, dict) and field.help_text:
             schema["description"] = field.help_text
         self.properties[name] = schema
         if field.required:

--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -78,7 +78,7 @@ class ObjectBuilder(Builder):
             [self.maybe_build(value) for _, value in self.properties.items()]
             return '#/definitions/{name}'.format(name=self.type_name)
         else:
-            return builder.build_definition(nullable=self.nullable)
+            return builder.build_definition()
 
     @property
     def type_name(self):
@@ -88,7 +88,7 @@ class ObjectBuilder(Builder):
         )
         return module_name.replace('.', '_').lower()
 
-    def build_definition(self, add_defintitions=True, nullable=False):
+    def build_definition(self, add_definitions=True):
         properties = dict(
             (name, self.maybe_build(value))
             for name, value
@@ -99,11 +99,14 @@ class ObjectBuilder(Builder):
             'additionalProperties': False,
             'properties': properties,
         }
+
         if self.required:
             schema['required'] = self.required
-        if self.definitions and add_defintitions:
+
+        if self.definitions and add_definitions:
             schema['definitions'] = dict(
-                (builder.type_name, builder.build_definition(False, False))
+                (builder.type_name,
+                 builder.build_definition(add_definitions=False))
                 for builder in self.definitions
             )
         return schema
@@ -156,9 +159,7 @@ class PrimitiveBuilder(Builder):
         elif issubclass(self.type, float):
             obj_type = 'number'
         else:
-            raise errors.FieldNotSupported(
-                "Can't specify value schema!", self.type
-            )
+            raise errors.FieldNotSupported(self.type)
 
         if self.nullable:
             obj_type = [obj_type, 'null']

--- a/jsonmodels/collections.py
+++ b/jsonmodels/collections.py
@@ -10,6 +10,7 @@ class ModelCollection(list):
     """
 
     def __init__(self, field):
+        super(ModelCollection, self).__init__()
         self.field = field
 
     def append(self, value):

--- a/jsonmodels/errors.py
+++ b/jsonmodels/errors.py
@@ -37,8 +37,10 @@ class FieldValidationError(ValidationError):
     """
     Enriches a validator error with the name of the field that caused it.
     """
-    def __init__(self, field_name: str, error: ValidatorError):
+    def __init__(self, model_name: str, field_name: str,
+                 given_value: any, error: ValidatorError):
         """
+        :param model_name: The name of the model.
         :param field_name: The name of the field.
         :param error: The validator error.
         """
@@ -46,7 +48,9 @@ class FieldValidationError(ValidationError):
         super(FieldValidationError, self).__init__(tpl.format(
             name=field_name, error=error
         ))
+        self.model_name = model_name
         self.field_name = field_name
+        self.given_value = given_value
         self.error = error
 
 
@@ -106,6 +110,7 @@ class AmbiguousTypeError(ValidatorError):
         super(AmbiguousTypeError, self).__init__(tpl.format(
             types=', '.join([t.__name__ for t in types])
         ))
+        self.types = types
 
 
 class MinLengthError(ValidatorError):

--- a/jsonmodels/errors.py
+++ b/jsonmodels/errors.py
@@ -13,13 +13,15 @@ class FieldNotFound(RuntimeError):
         """
         :param field_name: The name of the field.
         """
-        super().__init__('Field not found', field_name)
+        super(FieldNotFound, self).__init__('Field not found', field_name)
         self.field_name = field_name
 
 
 class FieldNotSupported(ValueError):
     def __init__(self, field_type: Type):
-        super().__init__("Can't specify value schema!", field_type)
+        super(FieldNotSupported, self).__init__(
+            "Can't specify value schema!", field_type
+        )
         self.field_type = field_type
 
 
@@ -41,7 +43,9 @@ class FieldValidationError(ValidationError):
         :param error: The validator error.
         """
         tpl = "Error for field '{name}': {error}"
-        super().__init__(tpl.format(name=field_name, error=error))
+        super(FieldValidationError, self).__init__(tpl.format(
+            name=field_name, error=error
+        ))
         self.field_name = field_name
         self.error = error
 
@@ -49,7 +53,7 @@ class FieldValidationError(ValidationError):
 class RequiredFieldError(ValidatorError):
     """ Error raised when a required field has no value """
     def __init__(self):
-        super().__init__('Field is required!')
+        super(RequiredFieldError, self).__init__('Field is required!')
 
 
 class RegexError(ValidatorError):
@@ -57,7 +61,9 @@ class RegexError(ValidatorError):
 
     def __init__(self, value: str, pattern: str):
         tpl = 'Value "{value}" did not match pattern "{pattern}".'
-        super().__init__(tpl.format(value=value, pattern=pattern))
+        super(RegexError, self).__init__(tpl.format(
+            value=value, pattern=pattern
+        ))
         self.value = value
         self.pattern = pattern
 
@@ -78,7 +84,7 @@ class BadTypeError(ValidatorError):
             tpl = 'All items must be instances of "{types}", and not "{type}".'
         else:
             tpl = 'Value is wrong, expected type "{types}", received {value}.'
-        super().__init__(tpl.format(
+        super(BadTypeError, self).__init__(tpl.format(
             types=', '.join([t.__name__ for t in types]),
             value=value,
             type=type(value).__name__
@@ -97,7 +103,7 @@ class AmbiguousTypeError(ValidatorError):
     def __init__(self, types: Tuple):
         """ The types that are allowed """
         tpl = 'Cannot decide which type to choose from "{types}".'
-        super().__init__(tpl.format(
+        super(AmbiguousTypeError, self).__init__(tpl.format(
             types=', '.join([t.__name__ for t in types])
         ))
 
@@ -111,7 +117,9 @@ class MinLengthError(ValidatorError):
         :param minimum_length: The minimum length expected.
         """
         tpl = "Value '{value}' length is lower than allowed minimum '{min}'."
-        super().__init__(tpl.format(value=value, min=minimum_length))
+        super(MinLengthError, self).__init__(tpl.format(
+            value=value, min=minimum_length
+        ))
         self.value = value
         self.minimum_length = minimum_length
 
@@ -125,7 +133,9 @@ class MaxLengthError(ValidatorError):
         :param maximum_length: The maximum length expected.
         """
         tpl = "Value '{value}' length is bigger than allowed maximum '{max}'."
-        super().__init__(tpl.format(value=value, max=maximum_length))
+        super(MaxLengthError, self).__init__(tpl.format(
+            value=value, max=maximum_length
+        ))
         self.value = value
         self.maximum_length = maximum_length
 
@@ -141,7 +151,9 @@ class MinValidationError(ValidatorError):
         """
         tpl = "'{value}' is lower or equal than minimum ('{min}')." \
             if exclusive else "'{value}' is lower than minimum ('{min}')."
-        super().__init__(tpl.format(value=value, min=minimum_value))
+        super(MinValidationError, self).__init__(tpl.format(
+            value=value, min=minimum_value
+        ))
         self.value = value
         self.minimum_value = minimum_value
         self.exclusive = exclusive
@@ -158,7 +170,9 @@ class MaxValidationError(ValidatorError):
         """
         tpl = "'{value}' is bigger or equal than maximum ('{max}')." \
             if exclusive else "'{value}' is bigger than maximum ('{max}')."
-        super().__init__(tpl.format(value=value, max=maximum_value))
+        super(MaxValidationError, self).__init__(tpl.format(
+            value=value, max=maximum_value
+        ))
         self.value = value
         self.maximum_value = maximum_value
         self.exclusive = exclusive
@@ -173,6 +187,6 @@ class EnumError(ValidatorError):
         :param choices: The allowed choices.
         """
         tpl = "Value '{val}' is not a valid choice."
-        super().__init__(tpl.format(val=value))
+        super(EnumError, self).__init__(tpl.format(val=value))
         self.value = value
         self.choices = choices

--- a/jsonmodels/errors.py
+++ b/jsonmodels/errors.py
@@ -1,15 +1,178 @@
+from typing import List, Tuple, Type
 
 
 class ValidationError(RuntimeError):
-
-    pass
+    """
+    The base validation error
+    """
 
 
 class FieldNotFound(RuntimeError):
-
-    pass
+    """ Error raised when a field is not found """
+    def __init__(self, field_name: str):
+        """
+        :param field_name: The name of the field.
+        """
+        super().__init__('Field not found', field_name)
+        self.field_name = field_name
 
 
 class FieldNotSupported(ValueError):
+    def __init__(self, field_type: Type):
+        super().__init__("Can't specify value schema!", field_type)
+        self.field_type = field_type
 
-    pass
+
+class ValidatorError(ValidationError):
+    """
+    Base error for all errors caused by a validator. These errors do not
+    contain any information about which field generated them. Models
+    should catch this error and convert it to a FieldValidationError.
+    """
+
+
+class FieldValidationError(ValidationError):
+    """
+    Enriches a validator error with the name of the field that caused it.
+    """
+    def __init__(self, field_name: str, error: ValidatorError):
+        """
+        :param field_name: The name of the field.
+        :param error: The validator error.
+        """
+        tpl = "Error for field '{name}': {error}"
+        super().__init__(tpl.format(name=field_name, error=error))
+        self.field_name = field_name
+        self.error = error
+
+
+class RequiredFieldError(ValidatorError):
+    """ Error raised when a required field has no value """
+    def __init__(self):
+        super().__init__('Field is required!')
+
+
+class RegexError(ValidatorError):
+    """ Error raised by the Regex validator """
+
+    def __init__(self, value: str, pattern: str):
+        tpl = 'Value "{value}" did not match pattern "{pattern}".'
+        super().__init__(tpl.format(value=value, pattern=pattern))
+        self.value = value
+        self.pattern = pattern
+
+
+class BadTypeError(ValidatorError):
+    """
+    Error raised when the user gives a type that does not match the
+    expected one
+    """
+
+    def __init__(self, value: any, types: Tuple, is_list: bool):
+        """
+        :param value: The given value.
+        :param types: The accepted types.
+        :param is_list: Whether the error occurred in the items of a list.
+        """
+        if is_list:
+            tpl = 'All items must be instances of "{types}", and not "{type}".'
+        else:
+            tpl = 'Value is wrong, expected type "{types}", received {value}.'
+        super().__init__(tpl.format(
+            types=', '.join([t.__name__ for t in types]),
+            value=value,
+            type=type(value).__name__
+        ))
+        self.value = value
+        self.types = types
+        self.is_array = is_list
+
+
+class AmbiguousTypeError(ValidatorError):
+    """
+    Error that occurs if the user gives a dictionary to an embedded field
+    that supports multiple types
+    """
+
+    def __init__(self, types: Tuple):
+        """ The types that are allowed """
+        tpl = 'Cannot decide which type to choose from "{types}".'
+        super().__init__(tpl.format(
+            types=', '.join([t.__name__ for t in types])
+        ))
+
+
+class MinLengthError(ValidatorError):
+    """ Error raised by the Length validator when too few items are present """
+
+    def __init__(self, value: list, minimum_length: int):
+        """
+        :param value: The given value.
+        :param minimum_length: The minimum length expected.
+        """
+        tpl = "Value '{value}' length is lower than allowed minimum '{min}'."
+        super().__init__(tpl.format(value=value, min=minimum_length))
+        self.value = value
+        self.minimum_length = minimum_length
+
+
+class MaxLengthError(ValidatorError):
+    """ Error raised by the Length validator when receiving too many items """
+
+    def __init__(self, value: list, maximum_length: int):
+        """
+        :param value: The given value.
+        :param maximum_length: The maximum length expected.
+        """
+        tpl = "Value '{value}' length is bigger than allowed maximum '{max}'."
+        super().__init__(tpl.format(value=value, max=maximum_length))
+        self.value = value
+        self.maximum_length = maximum_length
+
+
+class MinValidationError(ValidatorError):
+    """ Error raised by the Min validator """
+
+    def __init__(self, value, minimum_value, exclusive: bool):
+        """
+        :param value: The given value.
+        :param minimum_value: The minimum value allowed.
+        :param exclusive: Whether the validation is inclusive or not.
+        """
+        tpl = "'{value}' is lower or equal than minimum ('{min}')." \
+            if exclusive else "'{value}' is lower than minimum ('{min}')."
+        super().__init__(tpl.format(value=value, min=minimum_value))
+        self.value = value
+        self.minimum_value = minimum_value
+        self.exclusive = exclusive
+
+
+class MaxValidationError(ValidatorError):
+    """ Error raised by the Max validator """
+
+    def __init__(self, value, maximum_value, exclusive: bool):
+        """
+        :param value: The given value.
+        :param maximum_value: The maximum value allowed.
+        :param exclusive: Whether the validation is inclusive or not.
+        """
+        tpl = "'{value}' is bigger or equal than maximum ('{max}')." \
+            if exclusive else "'{value}' is bigger than maximum ('{max}')."
+        super().__init__(tpl.format(value=value, max=maximum_value))
+        self.value = value
+        self.maximum_value = maximum_value
+        self.exclusive = exclusive
+
+
+class EnumError(ValidatorError):
+    """ Error raised by the Enum validator """
+
+    def __init__(self, value: any, choices: List[any]):
+        """
+        :param value: The given value.
+        :param choices: The allowed choices.
+        """
+        tpl = "Value '{val}' is not a valid choice."
+        super().__init__(tpl.format(val=value))
+        self.value = value
+        self.choices = choices

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, List
+from typing import List
 
 import datetime
 import re
@@ -298,8 +298,7 @@ class DerivedListField(ListField):
     A list field that has another field for its items.
     """
 
-    def __init__(self, field: BaseField, help_text: str,
-                 validators: Optional[List[any]] = None):
+    def __init__(self, field: BaseField, *args, **kwargs):
         """
         :param field: The field that will be in each of the items of the list.
         :param help_text: The help text of the list field.
@@ -308,8 +307,7 @@ class DerivedListField(ListField):
         super(DerivedListField, self).__init__(
             items_types=field.types,
             item_validators=field.validators,
-            help_text=help_text,
-            validators=validators,
+            *args, **kwargs,
         )
         self._field = field
 
@@ -419,7 +417,7 @@ class MapField(BaseField):
             validating the values in this mapping.
         :param kwargs: Other keyword arguments to the base class.
         """
-        super().__init__(**kwargs)
+        super(MapField, self).__init__(**kwargs)
         self._key_field = key_field
         self._value_field = value_field
 
@@ -439,7 +437,7 @@ class MapField(BaseField):
         Validates all keys and values in the map field.
         :param values: The values in the mapping.
         """
-        super().validate(values)
+        super(MapField, self).validate(values)
         if not values:
             return
         for key, value in values.items():
@@ -596,3 +594,8 @@ class AnyField(BaseField):
 
     def _validate_against_types(self, value: any) -> None:
         """ This field does not validate its type. """
+
+    def to_struct(self, value):
+        from .models import Base
+        value = super().to_struct(value)
+        return value.to_struct() if isinstance(value, Base) else value

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -426,18 +426,21 @@ class MapField(BaseField):
 
     def parse_value(self, values: dict) -> dict:
         """ Parses the given values into a new dict. """
-        return {
-            self._key_field.parse_value(key):
-                self._value_field.parse_value(value)
+        dict_type = type(values)  # use same type to support OrderedDict
+        return dict_type([
+            (self._key_field.parse_value(key),
+             self._value_field.parse_value(value))
             for key, value in values.items()
-        }
+        ])
 
     def to_struct(self, values: dict) -> dict:
         """ Casts the field values into a dict. """
-        return {
-            self._key_field.to_struct(key): self._value_field.to_struct(value)
+        dict_type = type(values)  # use same type to support OrderedDict
+        return dict_type([
+            (self._key_field.to_struct(key),
+             self._value_field.to_struct(value))
             for key, value in values.items()
-        }
+        ])
 
     def validate(self, values: dict) -> None:
         """

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -162,7 +162,10 @@ class IntField(BaseField):
         parsed = super(IntField, self).parse_value(value)
         if parsed is None:
             return parsed
-        return int(parsed)
+        try:
+            return int(parsed)
+        except ValueError:
+            raise BadTypeError(value, types=(int,), is_list=False)
 
 
 class FloatField(BaseField):

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -414,6 +414,14 @@ class MapField(BaseField):
         """ Gets the default value for this field """
         return dict()
 
+    def parse_value(self, values: dict) -> dict:
+        """ Parses the given values into a new dict. """
+        return {
+            self._key_field.parse_value(key):
+                self._value_field.parse_value(value)
+            for key, value in values.items()
+        }
+
     def to_struct(self, values: dict) -> dict:
         """ Casts the field values into a dict. """
         return {
@@ -590,10 +598,13 @@ class GenericField(BaseField):
         from .models import Base
         if isinstance(values, Base):
             return values.to_struct()
+
         if isinstance(values, (list, tuple)):
             return [self.to_struct(value) for value in values]
+
         if isinstance(values, dict):
             items = [(self.to_struct(key), self.to_struct(value))
                      for key, value in values.items()]
             return type(values)(items)  # preserves OrderedDict
+
         return values

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -410,6 +410,16 @@ class MapField(BaseField):
         self._key_field = key_field
         self._value_field = value_field
 
+    def _finish_initialization(self, owner):
+        """
+        Completes the initialization of the fields, increasing
+        :param owner:
+        :return:
+        """
+        super(MapField, self)._finish_initialization(owner)
+        self._key_field._finish_initialization(owner)
+        self._value_field._finish_initialization(owner)
+
     def get_default_value(self) -> dict:
         """ Gets the default value for this field """
         return dict()

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -58,7 +58,8 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
         try:
             field.__set__(self, value)
         except ValidatorError as error:
-            raise FieldValidationError(field_name, error)
+            raise FieldValidationError(type(self).__name__, field_name,
+                                       value, error)
 
     def __iter__(self):
         """Iterate through fields and values."""
@@ -71,7 +72,9 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
             try:
                 field.validate_for_object(self)
             except ValidatorError as error:
-                raise FieldValidationError(name, error)
+                value = field.memory.get(self._cache_key)
+                raise FieldValidationError(type(self).__name__, name,
+                                           value, error)
 
     @classmethod
     def iterate_over_fields(cls):
@@ -126,7 +129,8 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
         try:
             return super(Base, self).__setattr__(name, value)
         except ValidatorError as error:
-            raise FieldValidationError(name, error)
+            raise FieldValidationError(type(self).__name__, name,
+                                       value, error)
 
     def __eq__(self, other):
         if type(other) is not type(self):

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -2,7 +2,7 @@ import six
 
 from . import parsers, errors
 from .fields import BaseField
-from .errors import ValidationError
+from .errors import FieldValidationError, ValidatorError, ValidationError
 
 
 class JsonmodelMeta(type):
@@ -19,10 +19,10 @@ class JsonmodelMeta(type):
         }
         taken_names = set()
         for name, field in fields.items():
-            structue_name = field.structue_name(name)
-            if structue_name in taken_names:
-                raise ValueError('Name taken', structue_name, name)
-            taken_names.add(structue_name)
+            structure_name = field.structure_name(name)
+            if structure_name in taken_names:
+                raise ValueError('Name taken', structure_name, name)
+            taken_names.add(structure_name)
 
 
 class Base(six.with_metaclass(JsonmodelMeta, object)):
@@ -51,15 +51,14 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
             if field_name == attr_name:
                 return field
 
-        raise errors.FieldNotFound('Field not found', field_name)
+        raise errors.FieldNotFound(field_name)
 
     def set_field(self, field, field_name, value):
         """ Sets the value of a field. """
         try:
             field.__set__(self, value)
-        except ValidationError as error:
-            raise ValidationError("Error for field '{name}': {error}"
-                                  .format(name=field_name, error=error))
+        except ValidatorError as error:
+            raise FieldValidationError(field_name, error)
 
     def __iter__(self):
         """Iterate through fields and values."""
@@ -71,28 +70,27 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
         for name, field in self:
             try:
                 field.validate_for_object(self)
-            except ValidationError as error:
-                raise ValidationError("Error for field '{name}': {error}"
-                                      .format(name=name, error=error))
+            except ValidatorError as error:
+                raise FieldValidationError(name, error)
 
     @classmethod
     def iterate_over_fields(cls):
         """Iterate through fields as `(attribute_name, field_instance)`."""
         for attr in dir(cls):
-            clsattr = getattr(cls, attr)
-            if isinstance(clsattr, BaseField):
-                yield attr, clsattr
+            class_attribute = getattr(cls, attr)
+            if isinstance(class_attribute, BaseField):
+                yield attr, class_attribute
 
     @classmethod
     def iterate_with_name(cls):
         """Iterate over fields, but also give `structure_name`.
 
-        Format is `(attribute_name, structue_name, field_instance)`.
+        Format is `(attribute_name, structure_name, field_instance)`.
         Structure name is name under which value is seen in structure and
         schema (in primitives) and only there.
         """
         for attr_name, field in cls.iterate_over_fields():
-            structure_name = field.structue_name(attr_name)
+            structure_name = field.structure_name(attr_name)
             yield attr_name, structure_name, field
 
     def to_struct(self):
@@ -127,9 +125,8 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
     def __setattr__(self, name, value):
         try:
             return super(Base, self).__setattr__(name, value)
-        except ValidationError as error:
-            raise ValidationError("Error for field '{name}': {error}"
-                                  .format(name=name, error=error))
+        except ValidatorError as error:
+            raise FieldValidationError(name, error)
 
     def __eq__(self, other):
         if type(other) is not type(self):
@@ -138,12 +135,12 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
         for name, _ in self.iterate_over_fields():
             try:
                 our = getattr(self, name)
-            except errors.ValidationError:
+            except ValidationError:
                 our = None
 
             try:
                 their = getattr(other, name)
-            except errors.ValidationError:
+            except ValidationError:
                 their = None
 
             if our != their:

--- a/jsonmodels/parsers.py
+++ b/jsonmodels/parsers.py
@@ -83,25 +83,34 @@ def build_json_schema_primitive(cls, parent_builder):
 
 
 def _create_primitive_field_schema(field):
+    schema = {'type': _get_schema_type(field)}
+
+    if isinstance(field, fields.FloatField):
+        schema['format'] = 'float'
+    elif isinstance(field, fields.DateField):
+        schema['format'] = 'date'
+    elif isinstance(field, fields.DateTimeField):
+        schema['format'] = 'date-time'
+
+    if field.has_default:
+        schema["default"] = field._default
+
+    return schema
+
+
+def _get_schema_type(field):
     if isinstance(field, fields.StringField):
         obj_type = 'string'
     elif isinstance(field, fields.IntField):
         obj_type = 'number'
     elif isinstance(field, fields.FloatField):
-        obj_type = 'float'
+        obj_type = 'number'
     elif isinstance(field, fields.BoolField):
         obj_type = 'boolean'
     elif isinstance(field, fields.GenericField):
         obj_type = 'object'
     else:
         raise errors.FieldNotSupported(type(field))
-
     if field.nullable:
         obj_type = [obj_type, 'null']
-
-    schema = {'type': obj_type}
-
-    if field.has_default:
-        schema["default"] = field._default
-
-    return schema
+    return obj_type

--- a/jsonmodels/parsers.py
+++ b/jsonmodels/parsers.py
@@ -91,12 +91,10 @@ def _create_primitive_field_schema(field):
         obj_type = 'float'
     elif isinstance(field, fields.BoolField):
         obj_type = 'boolean'
-    elif isinstance(field, fields.DictField):
+    elif isinstance(field, fields.GenericField):
         obj_type = 'object'
     else:
-        raise errors.FieldNotSupported(
-            'Field {field} is not supported!'.format(
-                field=type(field).__class__.__name__))
+        raise errors.FieldNotSupported(type(field))
 
     if field.nullable:
         obj_type = [obj_type, 'null']

--- a/jsonmodels/parsers.py
+++ b/jsonmodels/parsers.py
@@ -5,8 +5,8 @@ from . import fields, builders, errors
 
 
 def to_struct(model):
-    """Cast instance of model to python structure.
-
+    """
+    Cast instance of model to python structure.
     :param model: Model to be casted.
     :rtype: ``dict``
 
@@ -20,7 +20,8 @@ def to_struct(model):
             continue
 
         value = field.to_struct(value)
-        resp[name] = value
+        if value is not None:
+            resp[name] = value
     return resp
 
 

--- a/jsonmodels/utilities.py
+++ b/jsonmodels/utilities.py
@@ -44,12 +44,13 @@ def _compare_lists(one, two):
     if len(one) != len(two):
         return False
 
-    they_match = False
+    they_match = not one  # two empty lists are equal
     for first_item in one:
         for second_item in two:
             if they_match:
                 continue
             they_match = compare_schemas(first_item, second_item)
+
     return they_match
 
 
@@ -133,7 +134,7 @@ def convert_ecma_regex_to_python(value):
     return PythonRegex('/'.join(parts[1:]), result_flags)
 
 
-def convert_python_regex_to_ecma(value, flags=[]):
+def convert_python_regex_to_ecma(value, flags=()):
     """Convert Python regex to ECMA 262 regex.
 
     If given value is already ECMA regex it will be returned unchanged.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--e .
 Jinja2
 MarkupSafe
 Pygments

--- a/tests/fixtures/schema2.json
+++ b/tests/fixtures/schema2.json
@@ -32,12 +32,17 @@
                         }
                     }
                 },
-                "required": ["surname", "name"],
+                "required": ["name", "surname"],
                 "additionalProperties": false
             },
-            "type": "array"
+            "type": "array",
+            "default": [{
+                "name": "Name",
+                "surname": "Surname",
+                "toys": []
+            }]
         }
     },
-    "required": ["surname", "name"],
+    "required": ["name", "surname"],
     "additionalProperties": false
 }

--- a/tests/fixtures/schema3.json
+++ b/tests/fixtures/schema3.json
@@ -13,7 +13,8 @@
                             "type": "string"
                         },
                         "capacity": {
-                            "type": "float"
+                            "type": "number",
+                            "format": "float"
                         }
                     },
                     "type": "object"
@@ -25,7 +26,8 @@
                             "type": "string"
                         },
                         "velocity": {
-                            "type": "float"
+                            "type": "number",
+                            "format": "float"
                         }
                     },
                     "type": "object"
@@ -52,7 +54,8 @@
                         "additionalProperties": false,
                         "properties": {
                             "battery_voltage": {
-                                "type": "float"
+                                "type": "number",
+                                "format": "float"
                             },
                             "name": {
                                 "type": "string"

--- a/tests/fixtures/schema4.json
+++ b/tests/fixtures/schema4.json
@@ -2,10 +2,12 @@
     "additionalProperties": false,
     "properties": {
         "date": {
-            "type": "string"
+            "type": "string",
+            "format": "date"
         },
         "end": {
-            "type": "string"
+            "type": "string",
+            "format": "date-time"
         },
         "time": {
             "type": "string"

--- a/tests/fixtures/schema_circular2.json
+++ b/tests/fixtures/schema_circular2.json
@@ -26,7 +26,8 @@
                     "type": "string"
                 },
                 "size": {
-                    "type": "float"
+                    "type": "number",
+                    "format": "float"
                 }
             },
             "type": "object"

--- a/tests/fixtures/schema_enum.json
+++ b/tests/fixtures/schema_enum.json
@@ -2,6 +2,7 @@
     "additionalProperties": false,
     "properties": {
         "handness": {
+            "description": "The person's favorite hand.",
             "type": "string",
             "enum": ["left", "right"]
         }

--- a/tests/fixtures/schema_with_list.json
+++ b/tests/fixtures/schema_with_list.json
@@ -33,6 +33,7 @@
                     }
                 ]
             },
+            "description": "A list of names.",
             "type": "array"
         }
     },

--- a/tests/test_data_initialization.py
+++ b/tests/test_data_initialization.py
@@ -1,8 +1,9 @@
+import datetime
 import pytest
 import six
-import datetime
 
 from jsonmodels import models, fields, errors
+from jsonmodels.errors import FieldValidationError
 
 
 def test_initialization():
@@ -345,6 +346,10 @@ def test_int_field_parsing():
     counter2 = Counter(value='2')
     assert isinstance(counter2.value, int)
     assert counter2.value == 2
+
+    with pytest.raises(FieldValidationError):
+        Counter(value='2X')
+
     if not six.PY3:
         counter3 = Counter(value=long(3))  # noqa
         assert isinstance(counter3.value, int)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,13 @@
-from jsonmodels import models, fields
+import pytest
+from jsonmodels import models, fields, validators, errors
+
+
+def test_deprecated_structue_name():
+    field = fields.BoolField(name='field')
+    assert field.structue_name('default') == 'field'
+
+    field = fields.BoolField()
+    assert field.structue_name('default') == 'default'
 
 
 def test_bool_field():
@@ -28,3 +37,93 @@ def test_bool_field():
     assert field.parse_value(0) is False
     assert field.parse_value('') is False
     assert field.parse_value([]) is False
+
+
+def test_custom_field():
+    class NameField(fields.StringField):
+        def __init__(self):
+            super(NameField, self).__init__(required=True)
+
+    class Person(models.Base):
+        name = NameField()
+        surnames = fields.DerivedListField(NameField())
+
+    person = Person(name='Person')
+    person.surnames = ['Surname', 'Surname']
+
+    expected = {'name': 'Person', 'surnames': ['Surname', 'Surname']}
+    assert person.to_struct() == expected
+
+
+def test_custom_field_validation():
+    class NameField(fields.StringField):
+        def __init__(self):
+            super(NameField, self).__init__(
+                required=True,
+                validators=validators.Regex("[A-Z][a-z]+")
+            )
+
+    class Person(models.Base):
+        name = NameField()
+        surnames = fields.DerivedListField(NameField())
+
+    with pytest.raises(errors.FieldValidationError):
+        Person(name=None)
+
+    with pytest.raises(errors.FieldValidationError):
+        Person().name = "N"
+
+    with pytest.raises(errors.FieldValidationError):
+        Person(surnames=[None])
+
+    person = Person()
+    person.surnames.append(None)
+    with pytest.raises(errors.FieldValidationError):
+        person.validate()
+
+
+def test_map_field():
+    class Model(models.Base):
+        str_to_int = fields.MapField(fields.StringField(), fields.IntField())
+        int_to_str = fields.MapField(fields.IntField(), fields.StringField())
+
+    model = Model()
+    model.str_to_int = {"first": 1, "second": 2}
+    model.int_to_str = {1: "first", 2: "second"}
+
+    expected = {
+        "str_to_int": {"first": 1, "second": 2},
+        "int_to_str": {1: "first", 2: "second"},
+    }
+    assert expected == model.to_struct()
+
+
+def test_map_field_validation():
+    class Model(models.Base):
+        str_to_int = fields.MapField(fields.StringField(), fields.IntField())
+        int_to_str = fields.MapField(fields.IntField(), fields.StringField())
+
+    with pytest.raises(errors.FieldValidationError):
+        Model().str_to_int = {1: "first", 2: "second"}
+
+    with pytest.raises(errors.FieldValidationError):
+        Model().int_to_str = {"first": 1, "second": 2}
+
+    model = Model()
+    model.str_to_int[1] = "first"
+    with pytest.raises(errors.FieldValidationError):
+        model.validate()
+
+    model = Model()
+    model.int_to_str["first"] = 1
+    with pytest.raises(errors.FieldValidationError):
+        model.validate()
+
+
+def test_any_field():
+    class Model(models.Base):
+        field = fields.AnyField()
+
+    assert {"field": 1} == Model(field=1).to_struct()
+    assert {"field": "1"} == Model(field="1").to_struct()
+    assert {"field": {"field": {}}} == Model(field=Model(field={})).to_struct()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import pytest
 from jsonmodels import models, fields, validators, errors
 
@@ -120,10 +122,17 @@ def test_map_field_validation():
         model.validate()
 
 
-def test_any_field():
+def test_generic_field():
     class Model(models.Base):
-        field = fields.AnyField()
+        field = fields.GenericField()
 
-    assert {"field": 1} == Model(field=1).to_struct()
-    assert {"field": "1"} == Model(field="1").to_struct()
-    assert {"field": {"field": {}}} == Model(field=Model(field={})).to_struct()
+    model_int = Model(field=1)
+    model_str = Model(field="str")
+    model_model = Model(field=model_int)
+    model_ordered = Model(field=OrderedDict([("b", 2), ("a", 1)]))
+
+    assert {"field": 1} == model_int.to_struct()
+    assert {"field": "str"} == model_str.to_struct()
+    assert {"field": {"field": 1}} == model_model.to_struct()
+    expected = {"field": OrderedDict([("b", 2), ("a", 1)])}
+    assert expected == model_ordered.to_struct()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -100,6 +100,23 @@ def test_map_field():
     assert expected == model.to_struct()
 
 
+class CircularMapModel(models.Base):
+    """
+    Test model used in the following test,
+    must be defined outside function for lazy loading
+    """
+    mapping = fields.MapField(
+        fields.IntField(),
+        fields.EmbeddedField("CircularMapModel")
+    )
+
+
+def test_map_field_circular():
+    model = CircularMapModel(mapping={1: {}, 2: CircularMapModel()})
+    expected = {'mapping': {1: {'mapping': {}}, 2: {'mapping': {}}}}
+    assert expected == model.to_struct()
+
+
 def test_map_field_validation():
     class Model(models.Base):
         str_to_int = fields.MapField(fields.StringField(), fields.IntField())

--- a/tests/test_jsonmodels.py
+++ b/tests/test_jsonmodels.py
@@ -54,10 +54,10 @@ def test_base_field_should_not_be_usable():
 
     alan = Person()
 
-    with pytest.raises(errors.ValidationError):
+    with pytest.raises(ValueError):
         alan.name = 'some name'
 
-    with pytest.raises(errors.ValidationError):
+    with pytest.raises(ValueError):
         alan.name = 2345
 
 
@@ -110,6 +110,16 @@ def test_list_field_types():
 
     with pytest.raises(errors.ValidationError):
         viper.wheels.append(Wheel2)
+
+
+def test_list_omit_empty():
+
+    class Car(models.Base):
+        wheels = fields.ListField(items_types=[Wheel],
+                                  omit_empty=True)
+
+    viper = Car()
+    assert viper.to_struct() == {}
 
 
 def test_list_field_types_when_assigning():

--- a/tests/test_jsonmodels.py
+++ b/tests/test_jsonmodels.py
@@ -115,7 +115,7 @@ def test_list_field_types():
 def test_list_omit_empty():
 
     class Car(models.Base):
-        wheels = fields.ListField(items_types=[Wheel],
+        wheels = fields.ListField(items_types=[str],
                                   omit_empty=True)
 
     viper = Car()

--- a/tests/test_jsonmodels.py
+++ b/tests/test_jsonmodels.py
@@ -345,7 +345,7 @@ def test_repr():
 
     class Person2(models.Base):
 
-        name = fields.StringField()
+        name = fields.StringField(required=True)
         surname = fields.StringField()
         age = fields.IntField()
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -380,7 +380,10 @@ def test_schema_for_list_and_primitives():
 
     class Person(models.Base):
 
-        names = fields.ListField([str, int, float, bool, Event])
+        names = fields.ListField(
+            [str, int, float, bool, Event],
+            help_text="A list of names.",
+        )
 
     schema = Person.to_json_schema()
 
@@ -401,12 +404,12 @@ def test_schema_for_unsupported_primitive():
 def test_enum_validator():
     class Person(models.Base):
         handness = fields.StringField(
+            help_text="The person's favorite hand.",
             validators=validators.Enum('left', 'right')
         )
 
     schema = Person.to_json_schema()
     pattern = get_fixture('schema_enum.json')
-
     assert compare_schemas(pattern, schema)
 
 
@@ -434,7 +437,6 @@ def test_primitives():
         (str, "string"),
         (bool, "boolean"),
         (int, "number"),
-        (float, "number"),
     )
     for pytpe, jstype in cases:
         b = builders.PrimitiveBuilder(pytpe)
@@ -443,3 +445,11 @@ def test_primitives():
         assert b.build() == {"type": [jstype, "null"]}
         b = builders.PrimitiveBuilder(pytpe, nullable=True, default=0)
         assert b.build() == {"type": [jstype, "null"], "default": 0}
+
+    b = builders.PrimitiveBuilder(float)
+    assert b.build() == {"type": "number", "format": "float"}
+    b = builders.PrimitiveBuilder(float, nullable=True)
+    assert b.build() == {"type": ["number", "null"], "format": "float"}
+    b = builders.PrimitiveBuilder(float, nullable=True, default=0)
+    assert b.build() == {"type": ["number", "null"], "default": 0,
+                         "format": "float"}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -89,7 +89,7 @@ def test_model3():
         age = fields.IntField()
         car = fields.EmbeddedField([Viper, Lamborghini])
         computer = fields.ListField([PC, Laptop, Tablet])
-        meta = fields.DictField()
+        meta = fields.GenericField()
 
     schema = Person.to_json_schema()
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -44,7 +44,8 @@ def test_model2():
         name = fields.StringField(required=True)
         surname = fields.StringField(required=True)
         age = fields.IntField()
-        kids = fields.ListField(Kid)
+        kids = fields.ListField(Kid,
+                                default=[Kid(name="Name", surname="Surname")])
         car = fields.EmbeddedField(Car)
 
     chuck = Person()
@@ -117,21 +118,20 @@ def test_model_with_constructors():
         age = fields.IntField()
         toys = fields.ListField(Toy)
 
-        def __init__(self, some_value):
-            pass
+        def __init__(self, name="Name", surname="Surname"):
+            super().__init__(name=name, surname=surname)
 
     class Person(models.Base):
         name = fields.StringField(required=True)
         surname = fields.StringField(required=True)
         age = fields.IntField()
-        kids = fields.ListField(Kid)
+        kids = fields.ListField(Kid, default=[Kid()])
         car = fields.EmbeddedField(Car)
 
         def __init__(self, some_value):
             pass
 
     schema = Person.to_json_schema()
-
     pattern = get_fixture('schema2.json')
     assert compare_schemas(pattern, schema) is True
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -18,7 +18,7 @@ def test_to_struct_basic():
         surname = fields.StringField(required=True)
         age = fields.IntField()
         cash = fields.FloatField()
-        meta = fields.DictField()
+        meta = fields.GenericField()
 
     alan = Person()
     with pytest.raises(errors.ValidationError):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -59,129 +59,132 @@ def test_failed_comparison_of_two_dicts():
 
 
 def test_is_ecma_regex():
-    assert utilities.is_ecma_regex('some regex') is False
-    assert utilities.is_ecma_regex('^some regex$') is False
-    assert utilities.is_ecma_regex('/^some regex$/') is True
-    assert utilities.is_ecma_regex('/^some regex$/gim') is True
-    assert utilities.is_ecma_regex('/^some regex$/miug') is True
+    assert utilities.is_ecma_regex(r'some regex') is False
+    assert utilities.is_ecma_regex(r'^some regex$') is False
+    assert utilities.is_ecma_regex(r'/^some regex$/') is True
+    assert utilities.is_ecma_regex(r'/^some regex$/gim') is True
+    assert utilities.is_ecma_regex(r'/^some regex$/miug') is True
 
     with pytest.raises(ValueError):
-        utilities.is_ecma_regex('[wrong regex')
+        utilities.is_ecma_regex(r'[wrong regex')
     with pytest.raises(ValueError):
-        utilities.is_ecma_regex('wrong regex[]')
+        utilities.is_ecma_regex(r'wrong regex[]')
     with pytest.raises(ValueError):
-        utilities.is_ecma_regex('wrong regex(gim')
+        utilities.is_ecma_regex(r'wrong regex(gim')
     with pytest.raises(ValueError):
-        utilities.is_ecma_regex('wrong regex)asdf')
+        utilities.is_ecma_regex(r'wrong regex)asdf')
 
-    assert utilities.is_ecma_regex('/^some regex\/gim') is True
+    assert utilities.is_ecma_regex(r'/^some regex\/gim') is True
 
-    assert utilities.is_ecma_regex('/^some regex\\\\/miug') is True
-    assert utilities.is_ecma_regex('/^some regex\\\\\/gim') is True
-    assert utilities.is_ecma_regex('/\\\\/') is True
+    assert utilities.is_ecma_regex(r'/^some regex\\\\/miug') is True
+    assert utilities.is_ecma_regex(r'/^some regex\\\\\/gim') is True
+    assert utilities.is_ecma_regex(r'/\\\\/') is True
 
-    assert utilities.is_ecma_regex('some /regex/asdf') is False
-    assert utilities.is_ecma_regex('^some regex$//') is False
+    assert utilities.is_ecma_regex(r'some /regex/asdf') is False
+    assert utilities.is_ecma_regex(r'^some regex$//') is False
 
 
 def test_convert_ecma_regex_to_python():
-    assert ('some', []) == utilities.convert_ecma_regex_to_python('/some/')
     assert (
-        ('some/pattern', []) ==
-        utilities.convert_ecma_regex_to_python('/some/pattern/')
+        (r'some', []) ==
+        utilities.convert_ecma_regex_to_python(r'/some/')
     )
     assert (
-        ('^some \d+ pattern$', []) ==
-        utilities.convert_ecma_regex_to_python('/^some \d+ pattern$/')
+        (r'some/pattern', []) ==
+        utilities.convert_ecma_regex_to_python(r'/some/pattern/')
+    )
+    assert (
+        (r'^some \d+ pattern$', []) ==
+        utilities.convert_ecma_regex_to_python(r'/^some \d+ pattern$/')
     )
 
-    regex, flags = utilities.convert_ecma_regex_to_python('/^regex \d/i')
-    assert '^regex \d' == regex
+    regex, flags = utilities.convert_ecma_regex_to_python(r'/^regex \d/i')
+    assert r'^regex \d' == regex
     assert set([re.I]) == set(flags)
 
-    result = utilities.convert_ecma_regex_to_python('/^regex \d/m')
-    assert '^regex \d' == result.regex
+    result = utilities.convert_ecma_regex_to_python(r'/^regex \d/m')
+    assert r'^regex \d' == result.regex
     assert set([re.M]) == set(result.flags)
 
-    result = utilities.convert_ecma_regex_to_python('/^regex \d/mi')
-    assert '^regex \d' == result.regex
+    result = utilities.convert_ecma_regex_to_python(r'/^regex \d/mi')
+    assert r'^regex \d' == result.regex
     assert set([re.M, re.I]) == set(result.flags)
 
     with pytest.raises(ValueError):
-        utilities.convert_ecma_regex_to_python('/regex/wrong')
+        utilities.convert_ecma_regex_to_python(r'/regex/wrong')
 
     assert (
-        ('python regex', []) ==
-        utilities.convert_ecma_regex_to_python('python regex')
+        (r'python regex', []) ==
+        utilities.convert_ecma_regex_to_python(r'python regex')
     )
 
     assert (
-        ('^another \d python regex$', []) ==
-        utilities.convert_ecma_regex_to_python('^another \d python regex$')
+        (r'^another \d python regex$', []) ==
+        utilities.convert_ecma_regex_to_python(r'^another \d python regex$')
     )
 
-    result = utilities.convert_ecma_regex_to_python('python regex')
-    assert 'python regex' == result.regex
+    result = utilities.convert_ecma_regex_to_python(r'python regex')
+    assert r'python regex' == result.regex
     assert [] == result.flags
 
 
 def test_convert_python_regex_to_ecma():
     assert (
-        '/^some regex$/' ==
-        utilities.convert_python_regex_to_ecma('^some regex$')
+        r'/^some regex$/' ==
+        utilities.convert_python_regex_to_ecma(r'^some regex$')
     )
 
     assert (
-        '/^some regex$/' ==
-        utilities.convert_python_regex_to_ecma('^some regex$', [])
+        r'/^some regex$/' ==
+        utilities.convert_python_regex_to_ecma(r'^some regex$', [])
     )
 
     assert (
-        '/pattern \d+/i' ==
-        utilities.convert_python_regex_to_ecma('pattern \d+', [re.I])
+        r'/pattern \d+/i' ==
+        utilities.convert_python_regex_to_ecma(r'pattern \d+', [re.I])
     )
 
     assert (
-        '/pattern \d+/m' ==
-        utilities.convert_python_regex_to_ecma('pattern \d+', [re.M])
+        r'/pattern \d+/m' ==
+        utilities.convert_python_regex_to_ecma(r'pattern \d+', [re.M])
     )
 
     assert (
-        '/pattern \d+/im' ==
-        utilities.convert_python_regex_to_ecma('pattern \d+', [re.I, re.M])
+        r'/pattern \d+/im' ==
+        utilities.convert_python_regex_to_ecma(r'pattern \d+', [re.I, re.M])
     )
 
     assert (
-        '/ecma pattern$/' ==
-        utilities.convert_python_regex_to_ecma('/ecma pattern$/')
+        r'/ecma pattern$/' ==
+        utilities.convert_python_regex_to_ecma(r'/ecma pattern$/')
     )
 
     assert (
-        '/ecma pattern$/im' ==
-        utilities.convert_python_regex_to_ecma('/ecma pattern$/im')
+        r'/ecma pattern$/im' ==
+        utilities.convert_python_regex_to_ecma(r'/ecma pattern$/im')
     )
 
     assert (
-        '/ecma pattern$/wrong' ==
-        utilities.convert_python_regex_to_ecma('/ecma pattern$/wrong')
+        r'/ecma pattern$/wrong' ==
+        utilities.convert_python_regex_to_ecma(r'/ecma pattern$/wrong')
     )
 
     assert (
-        '/ecma pattern$/m' ==
-        utilities.convert_python_regex_to_ecma('/ecma pattern$/m', [re.M])
+        r'/ecma pattern$/m' ==
+        utilities.convert_python_regex_to_ecma(r'/ecma pattern$/m', [re.M])
     )
 
 
 def test_converters():
     assert (
-        '/^ecma \d regex$/im' ==
+        r'/^ecma \d regex$/im' ==
         utilities.convert_python_regex_to_ecma(
-            *utilities.convert_ecma_regex_to_python('/^ecma \d regex$/im'))
+            *utilities.convert_ecma_regex_to_python(r'/^ecma \d regex$/im'))
     )
 
     result = utilities.convert_ecma_regex_to_python(
         utilities.convert_python_regex_to_ecma(
-            '^some \w python regex$', [re.I]))
+            r'^some \w python regex$', [re.I]))
 
-    assert '^some \w python regex$' == result.regex
+    assert r'^some \w python regex$' == result.regex
     assert [re.I] == result.flags


### PR DESCRIPTION
This PR adds the following features:
- New [fields](https://github.com/Ultimaker/jsonmodels/blob/928faccef7139b870aa75b4eaefc4a1b45071986/jsonmodels/fields.py):
  - DerivedListField(field) can be used to create a list of custom/validated primitives
  - MapField(key_field, value_field) can be used to create a dict based off two other fields
  - GenericField() accepts any kind of value, but converts it's contents accordingly
- Fields improvements
  - (Derived)ListField accepts an `omit_empty` argument to hide it from the output when no items are given
  - [Validation errors](https://github.com/Ultimaker/jsonmodels/blob/928faccef7139b870aa75b4eaefc4a1b45071986/jsonmodels/errors.py) are much more specific and contain metadata
  - [Automatic model type detection](https://github.com/Ultimaker/jsonmodels/blob/928faccef7139b870aa75b4eaefc4a1b45071986/jsonmodels/fields.py#L118)
- Json schemas improvements:
  - Floats and datetimes now have the correct 'type' and 'format'
  - Fields with 'help_text' get a description in the output schema