### PR TITLE
Add toPlain method on fields [cs-452]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Packages
 *.egg
+*.eggs
 *.egg-info
 dist
 build

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -14,7 +14,7 @@ from .errors import RequiredFieldError, BadTypeError, AmbiguousTypeError
 # it is a completely valid default value.
 NotSet = object()
 
-# BSON compatible types, which can be returned by toPlain.
+# BSON compatible types, which can be returned by toBsonEncodable.
 BsonEncodable = Union[
     float, str, object, Dict, List, bytes, bool, datetime.datetime, None,
     Pattern, int, bytes
@@ -131,13 +131,13 @@ class BaseField(object):
             return matching_models[0]
         return models[0]
 
-    def toPlain(self, value: types) -> BsonEncodable:
-        """Optionally return a python object instead of JSON compatible value.
+    def toBsonEncodable(self, value: types) -> BsonEncodable:
+        """Optionally return a bson encodable python object.
 
         Returned object should be BSON compatible. By default uses the
         `to_struct` method, which creates JSON compatible types. JSON is
-        compatible with bson. When required, this method should cast the value
-        to supported bson type.
+        compatible with bson, but only has support for limited types. When
+        required, this method should cast the value to supported bson type.
         See: https://api.mongodb.com/python/current/api/bson/index.html
 
         For example: when a value is a datetime object return it as a datetime
@@ -146,7 +146,6 @@ class BaseField(object):
 
         :param value: Value
         :return: a value which should be bson encodable
-
         """
         return self.to_struct(value=value)
 

--- a/tests/test_plain.py
+++ b/tests/test_plain.py
@@ -4,8 +4,8 @@ from jsonmodels import fields
 
 
 @mock.patch('jsonmodels.fields.BaseField.to_struct')
-def test_toPlain_calls_to_struct(f):
-    """Test if default implementation of toPlain calls to_struct."""
+def test_toBsonEncodable_calls_to_struct(f):
+    """Test if default implementation of toBsonEncodable calls to_struct."""
     field = fields.StringField()
-    field.toPlain(value="text")
+    field.toBsonEncodable(value="text")
     f.assert_called_once()

--- a/tests/test_plain.py
+++ b/tests/test_plain.py
@@ -1,0 +1,11 @@
+from unittest import mock
+
+from jsonmodels import fields
+
+
+@mock.patch('jsonmodels.fields.BaseField.to_struct')
+def test_toPlain_calls_to_struct(f):
+    """Test if default implementation of toPlain calls to_struct."""
+    field = fields.StringField()
+    field.toPlain(value="text")
+    f.assert_called_once()


### PR DESCRIPTION
toPlain is used by BaseModel when plain objects are requested.