### PR TITLE
Add support for `MapField` in JSON schema

### DIFF
--- a/jsonmodels/parsers.py
+++ b/jsonmodels/parsers.py
@@ -55,6 +55,8 @@ def build_json_schema_object(cls, parent_builder=None):
             builder.add_field(name, field, _parse_embedded(field, builder))
         elif isinstance(field, fields.ListField):
             builder.add_field(name, field, _parse_list(field, builder))
+        elif isinstance(field, fields.MapField):
+            builder.add_field(name, field, 'object')
         else:
             builder.add_field(
                 name, field, _create_primitive_field_schema(field))

--- a/tests/fixtures/schema_map.json
+++ b/tests/fixtures/schema_map.json
@@ -1,0 +1,1 @@
+{"type": "object", "additionalProperties": false, "properties": {"data": "object"}}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -453,3 +453,16 @@ def test_primitives():
     b = builders.PrimitiveBuilder(float, nullable=True, default=0)
     assert b.build() == {"type": ["number", "null"], "default": 0,
                          "format": "float"}
+
+
+def test_map_field():
+    class FaultData(models.Base):
+        data = fields.MapField(
+            key_field=fields.StringField(),
+            value_field=fields.StringField()
+        )
+
+    schema = FaultData.to_json_schema()
+    pattern = get_fixture('schema_map.json')
+
+    assert compare_schemas(pattern, schema)


### PR DESCRIPTION
Fields of type `MapField` are just mapped to JSON schema `object`. It is a catch-all for arbitrary key to value mappings with no fixed key names.
