### PR TITLE
CS-1097 Ignore spec generation if Enum items are not strings

### DIFF
--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -142,6 +142,10 @@ def _apply_validators_modifications(field_schema, field):
                 validator.modify_schema(field_schema["items"])
             except AttributeError:
                 pass
+            except TypeError:
+                # ignore the cases in which the items are not strings, until we know
+                # how to deal with openapi enums that are not strings (CS-1097)
+                pass
 
 
 class PrimitiveBuilder(Builder):

--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -127,7 +127,7 @@ class ObjectBuilder(Builder):
         return not bool(self.parent)
 
 
-def _apply_validators_modifications(field_schema, field):
+def _apply_validators_modifications(field_schema, field):  # noqa: ignore=C901
     for validator in field.validators:
         try:
             validator.modify_schema(field_schema)
@@ -143,8 +143,9 @@ def _apply_validators_modifications(field_schema, field):
             except AttributeError:
                 pass
             except TypeError:
-                # ignore the cases in which the items are not strings, until we know
-                # how to deal with openapi enums that are not strings (CS-1097)
+                # ignore the cases in which the items are not strings,
+                # until we know how to deal with Enums that are not strings
+                # (CS-1097)
                 pass
 
 

--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -143,9 +143,8 @@ def _apply_validators_modifications(field_schema, field):  # noqa: ignore=C901
             except AttributeError:
                 pass
             except TypeError:
-                # ignore the cases in which the items are not strings,
-                # until we know how to deal with Enums that are not strings
-                # (CS-1097)
+                # CS-1097 ignore the cases in which the items are not strings,
+                # until OpenAPI spec supports generating non-string Enum items
                 pass
 
 


### PR DESCRIPTION
In the development of the material properties (CS-1097), we created attributes in `PackageData` as a list field, with non-string items as `item_validators`:

```
    polymer_classes = fields.ListField(
        items_types=PackageProperty,
        required=False,
        omit_empty=True,
        help_text="A list of polymer classes applicable to the package.",
        item_validators=[POLYMER_CLASSES_PROPERTY_VALIDATION]
    )
```

The jsonmodel validator complained about it, because the Enum items are not strings, but objects, and finally resulted in `TypeError`. In this PR, when it sees such an `TypeError`, we ignore the spec generation. Later if we find a way to generate the spec correctly, we'll fix it.

Also see the error log below:

```
______________________ TestDocumentationSnapshot.test_v3 _______________________

self = <tests.api.http.TestApiSpecificationHandler.TestDocumentationSnapshot object at 0x7f0a265bb5b0>

    def test_v3(self):
        generator = DocumentationGenerator("3.0")
>       spec = generator.generate(self.APP)

lib/stardustCommons/tests/helpers/documentation/TestDocumentationGenerator.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/stardustCommons/helpers/DocumentationGenerator.py:44: in generate
    return self._generator.generate(self._version, app, path_predicate)
lib/stardustCommons/helpers/documentation/TornadoDocumentationGenerator.py:82: in generate
    spec.components.schemas = self._getSchemas(all_models)
lib/stardustCommons/helpers/documentation/TornadoDocumentationGenerator.py:94: in _getSchemas
    schema, sub_models = self.generateModelSchema(model)
lib/stardustCommons/helpers/documentation/TornadoDocumentationGenerator.py:107: in generateModelSchema
    schema = model_class.to_json_schema()
/home/python/lib/python3.8/site-packages/jsonmodels/models.py:106: in to_json_schema
    return parsers.to_json_schema(cls)
/home/python/lib/python3.8/site-packages/jsonmodels/parsers.py:35: in to_json_schema
    builder = build_json_schema(cls)
/home/python/lib/python3.8/site-packages/jsonmodels/parsers.py:44: in build_json_schema
    return build_json_schema_object(cls, parent_builder)
/home/python/lib/python3.8/site-packages/jsonmodels/parsers.py:55: in build_json_schema_object
    builder.add_field(name, field, _parse_embedded(field, builder))
/home/python/lib/python3.8/site-packages/jsonmodels/parsers.py:79: in _parse_embedded
    builder.add_type_schema(build_json_schema(type, builder))
/home/python/lib/python3.8/site-packages/jsonmodels/parsers.py:44: in build_json_schema
    return build_json_schema_object(cls, parent_builder)
/home/python/lib/python3.8/site-packages/jsonmodels/parsers.py:57: in build_json_schema_object
    builder.add_field(name, field, _parse_list(field, builder))
/home/python/lib/python3.8/site-packages/jsonmodels/builders.py:69: in add_field
    _apply_validators_modifications(schema, field)
/home/python/lib/python3.8/site-packages/jsonmodels/builders.py:142: in _apply_validators_modifications
    validator.modify_schema(field_schema["items"])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <jsonmodels.validators.Enum object at 0x7f0a28c05e80>
field_schema = '#/definitions/stardustcurapackagesapi_models_database_packageproperty_packageproperty'

    def modify_schema(self, field_schema):
>       field_schema['enum'] = self.choices
E       TypeError: 'str' object does not support item assignment

/home/python/lib/python3.8/site-packages/jsonmodels/validators.py:187: TypeError
```