### PR TITLE
Fix: no longer fix the jsonmodels version

### DIFF
--- a/jsonmodels/__init__.py
+++ b/jsonmodels/__init__.py
@@ -1,5 +1,1 @@
 # coding: utf-8
-
-__author__ = 'Szczepan Cieślik'
-__email__ = 'szczepan.cieslik@gmail.com'
-__version__ = '2.4'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 from setuptools.command.test import test as TestCommand
-from jsonmodels import __version__, __author__, __email__
 
 from setuptools import setup
 
@@ -54,12 +53,9 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name=PROJECT_NAME,
-    version=__version__,
     description='Models to make easier to deal with structures that'
     ' are converted to, or read from JSON.',
     long_description=readme + '\n\n' + history,
-    author=__author__,
-    author_email=__email__,
     url='https://github.com/beregond/jsonmodels',
     packages=[
         PROJECT_NAME,


### PR DESCRIPTION
When working with polymer classes and material characteristics, we found out that jsonmodels was always installed in `jsonmodels==2.4`, which is not the desired version we want. It turned out to be that in `setup.py` the version is written to the metadata.

Since they are optional (https://docs.python.org/3.8/distutils/setupscript.html#additional-meta-data), we remove them. The test shows that if the version is removed from `setup.py`, the specified tag/version will be installed correctly.