### PR TITLE
Fix toBsonEncodable for lists

### DIFF
--- a/jsonmodels/__init__.py
+++ b/jsonmodels/__init__.py
@@ -1,1 +1,2 @@
 # coding: utf-8
+__version__ = "2.8.4"

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -1,4 +1,3 @@
-import warnings
 from weakref import WeakKeyDictionary
 
 import datetime
@@ -150,7 +149,7 @@ class BaseField(object):
         :param value: Value
         :return: a value which should be bson encodable
         """
-        return self.to_struct(value=value)
+        return self.to_struct(value)
 
     def to_struct(self, value):
         """Cast value to Python dict."""
@@ -191,11 +190,6 @@ class BaseField(object):
 
     def structure_name(self, default):
         return self.name if self.name is not None else default
-
-    def structue_name(self, default):
-        warnings.warn("`structue_name` is deprecated, please use "
-                      "`structure_name`")
-        return self.structure_name(default)
 
 
 class StringField(BaseField):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,14 +6,6 @@ import pytest
 from jsonmodels import models, fields, validators, errors
 
 
-def test_deprecated_structue_name():
-    field = fields.BoolField(name='field')
-    assert field.structue_name('default') == 'field'
-
-    field = fields.BoolField()
-    assert field.structue_name('default') == 'default'
-
-
 def test_bool_field():
 
     field = fields.BoolField()

--- a/tests/test_plain.py
+++ b/tests/test_plain.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 
 from jsonmodels import fields
@@ -9,3 +10,10 @@ def test_toBsonEncodable_calls_to_struct(f):
     field = fields.StringField()
     field.toBsonEncodable(value="text")
     f.assert_called_once()
+
+
+def test_toBsonEncodable_lists():
+    """Test if default implementation of toBsonEncodable works for lists."""
+    field = fields.ListField(items_types=(datetime, str))
+    values = ["text", datetime(2021, 1, 1)]
+    assert field.toBsonEncodable(value=values) == values


### PR DESCRIPTION
The keyword argument is renamed in some fields, using a positional argument fixes the issue.