### PR TITLE
Build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM python:3.7 AS base
 WORKDIR /usr/src/app
 RUN apt-get update \
-    && apt-get install -y enchant \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Pygments
 Sphinx
 coverage
 docutils
+importlib_metadata<5
 flake8; python_version == '2.7' or python_version >= '3.4'
 invoke
 mccabe


### PR DESCRIPTION
Remove enchanted spellchecker and pin the `importlib_metadata` library to version 4

See https://github.com/python/importlib_metadata/issues/406 for details on flake8 bug